### PR TITLE
Fix README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,14 @@ This is a **Flask-based web application** that helps users find optimal places t
 ## Installation
 
 ### 1. Clone the Repository
-bash
+```bash
 git clone https://github.com/your-username/your-repo-name.git
 cd your-repo-name
 python3 -m venv venv
 source venv/bin/activate  # On Windows use: venv\Scripts\activate
 pip install -r requirements.txt
 python app.py
+```
 
 
 Configuration


### PR DESCRIPTION
## Summary
- wrap installation commands in a fenced `bash` block
- remove stray `bash` line from README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685db0e73e6083248c6befc7d0f1f2cf