### PR TITLE
Refactor compute_weekly_travel_time

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -103,13 +103,15 @@ def compute_weekly_travel_time(G, connections_df, base_station, destinations_dat
         base_node = get_start_node(G, base_station)
     except Exception as e:
         raise Exception(f"Base station error: {e}")
+    # Compute all shortest-path distances from the base node once
+    distances = nx.single_source_dijkstra_path_length(G, base_node, weight=weight)
+
     total_weekly_time = 0.0
     for dest_name, visits in destinations_data:
         try:
             dest_node = get_start_node(G, dest_name)
         except Exception as e:
             raise Exception(f"Destination error: {e}")
-        distances = nx.single_source_dijkstra_path_length(G, base_node, weight=weight)
         travel_time = distances.get(dest_node)
         if travel_time is None:
             raise Exception(f"No connection from {base_station} to {dest_name}.")

--- a/backend/housing_tool_functions.py
+++ b/backend/housing_tool_functions.py
@@ -454,13 +454,15 @@ def compute_weekly_travel_time(G, connections_df, base_station, destinations_dat
         base_node = get_start_node(G, base_station)
     except Exception as e:
         raise Exception(f"Base station error: {e}")
+    # Compute all shortest-path distances from the base node once
+    distances = nx.single_source_dijkstra_path_length(G, base_node, weight=weight)
+
     total_weekly_time = 0.0
     for dest_name, visits in destinations_data:
         try:
             dest_node = get_start_node(G, dest_name)
         except Exception as e:
             raise Exception(f"Destination error: {e}")
-        distances = nx.single_source_dijkstra_path_length(G, base_node, weight=weight)
         travel_time = distances.get(dest_node)
         
         # Debugging print statements:

--- a/tests/test_travel_time.py
+++ b/tests/test_travel_time.py
@@ -41,3 +41,17 @@ def test_unreachable_destination():
     G.add_node(4, name="D")  # isolated node
     with pytest.raises(Exception, match="No connection from A to D"):
         compute_weekly_travel_time(G, pd.DataFrame(), "A", [("D", 1)])
+
+
+def test_compute_weekly_travel_time_multiple_destinations():
+    G = build_graph()
+    destinations = [("B", 1), ("C", 1), ("B", 2)]
+    total = compute_weekly_travel_time(G, pd.DataFrame(), "A", destinations)
+    assert total == 45
+
+
+def test_compute_weekly_travel_time_zero_visits():
+    G = build_graph()
+    destinations = [("B", 0), ("C", 2)]
+    total = compute_weekly_travel_time(G, pd.DataFrame(), "A", destinations)
+    assert total == 30


### PR DESCRIPTION
## Summary
- refactor compute_weekly_travel_time to precompute distances
- duplicate refactor in backend/app.py
- add unit tests covering additional destination sets

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_685db66e33908324959eb71ae9a5811b